### PR TITLE
Support copying private links instead of public links

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -733,17 +733,18 @@ void ApiWrap::finalizeMessageDataRequest(
 	}
 }
 
-QString ApiWrap::exportDirectMessageLink(not_null<HistoryItem*> item) {
+QString ApiWrap::exportDirectMessageLink(not_null<HistoryItem*> item, bool forcePrivate) {
 	Expects(item->history()->peer->isChannel());
 
 	const auto itemId = item->fullId();
 	const auto channel = item->history()->peer->asChannel();
+	const auto useUsername = channel->hasUsername() && !forcePrivate;
 	const auto fallback = [&] {
-		const auto base = channel->hasUsername()
+		const auto base = useUsername
 			? channel->username
 			: "c/" + QString::number(channel->bareId());
 		const auto query = base + '/' + QString::number(item->id);
-		if (channel->hasUsername() && !channel->isMegagroup()) {
+		if (useUsername && !channel->isMegagroup()) {
 			if (const auto media = item->media()) {
 				if (const auto document = media->document()) {
 					if (document->isVideoMessage()) {

--- a/Telegram/SourceFiles/apiwrap.h
+++ b/Telegram/SourceFiles/apiwrap.h
@@ -164,7 +164,7 @@ public:
 		ChannelData *channel,
 		MsgId msgId,
 		RequestMessageDataCallback callback);
-	QString exportDirectMessageLink(not_null<HistoryItem*> item);
+	QString exportDirectMessageLink(not_null<HistoryItem*> item, bool forcePrivate = false);
 
 	void requestContacts();
 	void requestDialogs(Data::Folder *folder = nullptr);

--- a/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
@@ -632,18 +632,18 @@ base::unique_qptr<Ui::PopupMenu> FillContextMenu(
 	return result;
 }
 
-void CopyPostLink(FullMsgId itemId) {
+void CopyPostLink(FullMsgId itemId, bool forcePrivate) {
 	const auto item = Auth().data().message(itemId);
 	if (!item || !item->hasDirectLink()) {
 		return;
 	}
 	QGuiApplication::clipboard()->setText(
-		item->history()->session().api().exportDirectMessageLink(item));
+		item->history()->session().api().exportDirectMessageLink(item, forcePrivate));
 
 	const auto channel = item->history()->peer->asChannel();
 	Assert(channel != nullptr);
 
-	Ui::Toast::Show(channel->hasUsername()
+	Ui::Toast::Show(channel->hasUsername() && !forcePrivate
 		? tr::lng_channel_public_link_copied(tr::now)
 		: tr::lng_context_about_private_link(tr::now));
 }

--- a/Telegram/SourceFiles/history/view/history_view_context_menu.h
+++ b/Telegram/SourceFiles/history/view/history_view_context_menu.h
@@ -43,7 +43,7 @@ base::unique_qptr<Ui::PopupMenu> FillContextMenu(
 	not_null<ListWidget*> list,
 	const ContextMenuRequest &request);
 
-void CopyPostLink(FullMsgId itemId);
+void CopyPostLink(FullMsgId itemId, bool forcePrivate = false);
 void StopPoll(FullMsgId itemId);
 
 } // namespace


### PR DESCRIPTION
This PR tracks progress for option to copy private link instead of public one.

### Why bother?
1. These links won't generate any previews (even if channel/supergroup has a public username).
2. These links will work even if channel/group username will be changed, since IDs are static.

### Current state
* [x] Support to copy private links
* [ ] Way to activate it

### About how to activate it
For me, I think that best option here is to Shift/Ctrl+click on "Copy post link" option. But since I'm not seeing a way to make it with `Ui::PopupMenu`, here is some alternatives:

* **Adding a separate "Copy private link" option.** It's visible, but menu will grow.
* **Kotatogram Settings option.** Yes, settings menu will also grow, but that's inevitable. Much bigger problem here is that if you want to copy other link, you need to open settings menu.

So, most favorable option is Shift/Ctrl+click. Hope I don't need to hack `Ui::PopupMenu` for this.