### PR TITLE
Replaced chimare with chiamare in italian language

### DIFF
--- a/Telegram/Resources/langs/rewrites/it.json
+++ b/Telegram/Resources/langs/rewrites/it.json
@@ -75,7 +75,7 @@
 	"ktg_profile_supergroup_id": "ID Supergruppo",
 	"ktg_profile_channel_id": "ID Canale",
 	"ktg_settings_show_phone_number": "Mostra numero tel. nel drawer",
-	"ktg_settings_call_confirm": "Conferma prima di chimare",
+	"ktg_settings_call_confirm": "Conferma prima di chiamare",
 	"ktg_call_sure": "Sei sicuro di voler chiamare questo utente?",
 	"ktg_call_button": "Chiama",
 	"ktg_settings_adaptive_bubbles": "Bolle adattive",


### PR DESCRIPTION
This is the correct translation